### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
+.babelrc
 examples


### PR DESCRIPTION
No further transformation is made, we can ignore .babelrc.

Also Fixes babel import errors (babel6)
