### PR TITLE
Initialize SoundManager when it’s lazy loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,18 @@ import React, {PropTypes as T} from 'react';
 import { soundManager } from 'soundmanager2';
 
 const pendingCalls = [];
+let initialized = false;
 
 function createSound(options, cb) {
   if (soundManager.ok()) {
     cb(soundManager.createSound(options));
     return () => {};
   } else {
+    if (!initialized) {
+      initialized = true;
+      soundManager.beginDelayedInit();
+    }
+
     const call = () => {
       cb(soundManager.createSound(options));
     };


### PR DESCRIPTION
Should fix #9. Not sure if there's a cleaner way to do it, but this seems to be pretty canonical based on the docs.
