### PR TITLE
Use soundManager’s production build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React, {PropTypes as T} from 'react';
-import { soundManager } from 'soundmanager2';
+import { soundManager } from 'soundmanager2/script/soundmanager2-nodebug-jsmin.js';
 
 const pendingCalls = [];
 


### PR DESCRIPTION
Import the production build of SoundManager2 (`soundmanager2-nodebug-jsmin.js`) instead of the base/debug version (`soundManager2.js`).

We can probably allow the user to pass a prop for debug/prod versions, but I think in this case it's better to just make the API clean and simply bundle the production build as a default.
