### PR TITLE
Allow Other options to be Passed to soundmanager2's createSound

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ var MyComponentWithSound = React.createClass({
 * *onLoading (function)*: Function that gets called while the sound is loading. It receives an object with properties `bytesLoaded`, `bytesTotal` and `duration`.
 * *onPlaying (function)*: Function that gets called while the sound is playing. It receives an object with properties `position` and `duration`.
 * *onFinishedPlaying (function)*: Function that gets called when the sound finishes playing (reached end of sound). It receives no parameters.
+* *options (object)*: any other options to be passed to soundmanager2's [createSound](http://www.schillmania.com/projects/soundmanager2/doc/) method.
 
 ## How to contribute
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ export default class Sound extends React.Component {
     playStatus: T.oneOf(Object.keys(playStatuses)).isRequired,
     position: T.number,
     playFromPosition: T.number,
+    options: T.object,
     volume: T.number,
     onLoading: T.func,
     onPlaying: T.func,
@@ -126,6 +127,7 @@ export default class Sound extends React.Component {
     if (!props.url) { return; }
 
     this.stopCreatingSound = createSound({
+      ...this.props.options,
       url: this.props.url,
       volume: props.volume,
       whileloading() {


### PR DESCRIPTION
Parameters like autoPlay, autoLoad are not commonly used. However, it would be nice to support those.
