### PR TITLE
Add multiple audio support for mobile

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ export default class Sound extends React.Component {
   };
 
   componentDidMount() {
+    soundManager.setup({ignoreMobileRestrictions: true});
     this.createSound(sound => {
       if (this.props.playStatus === playStatuses.PLAYING) {
         sound.play();


### PR DESCRIPTION
On mobile, by default, a Singleton is used for audio (the Audio object). In case you want to play multiple sounds, you need to override this limitation.

Per soundManager2 [specs](http://www.schillmania.com/projects/soundmanager2/doc/), you can do so by setting the ignoreMobileRestrictions.

I enabled so in the componentDidMount. And this sould fix #15 