### PR TITLE
Update React min version requirements supporting prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "license": "ISC",
   "homepage": "https://github.com/leoasis/react-sound",
   "dependencies": {
-    "react": ">=0.13.3 <16.0.0",
+    "prop-types": "15.5.8",
+    "react": ">=15.3.0 <16.0.0",
     "soundmanager2": "^2.97.20150601-a"
   },
   "devDependencies": {
@@ -31,8 +32,8 @@
     "eslint": "^2.13.1",
     "eslint-plugin-react": "5.2.2",
     "node-libs-browser": "^0.5.2",
-    "react-dom": ">=0.14.0 <16.0.0",
-    "react-hot-loader": "^1.2.7",
+    "react-dom": ">=15.3.0 <16.0.0",
+    "react-hot-loader": "^1.3.1",
     "rimraf": "^2.4.0",
     "webpack": "^1.9.10",
     "webpack-dev-server": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "homepage": "https://github.com/leoasis/react-sound",
   "dependencies": {
-    "prop-types": "15.5.8",
+    "prop-types": "^15.5.7",
     "react": ">=15.3.0 <16.0.0",
     "soundmanager2": "^2.97.20150601-a"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, {PropTypes as T} from 'react';
+import React from 'react';
+import T from 'prop-types';
 import { soundManager } from 'soundmanager2';
 
 const pendingCalls = [];


### PR DESCRIPTION
Hello, as I'm sure you already know `PropTypes` usage directly from React was recently deprecated and now requires use from the independent `prop-types` package. Unfortunately `react-sound` currently will throw warnings because of this in any application it's used in.

This PR addresses this issue, updating the lib to use the `prop-types` package while also upgrading the minimum supported React version to `15.3.0` (`prop-types` only supports React 0.14.9 and > 15.3.0, I believe it's best to avoid confusion and simply keep > 15.3.0).