### PR TITLE
Add debug mode option to component

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ render() {
       playFromPosition={300 /* in milliseconds */}
       onLoading={this.handleSongLoading}
       onPlaying={this.handleSongPlaying}
-      onFinishedPlaying={this.handleSongFinishedPlaying} 
+      onFinishedPlaying={this.handleSongFinishedPlaying}
+      debug={true}
     />
   );
 }
@@ -63,6 +64,7 @@ class MyComponentWithSound extends React.Component {
 * *onLoading (function)*: Function that gets called while the sound is loading. It receives an object with properties `bytesLoaded`, `bytesTotal` and `duration`.
 * *onPlaying (function)*: Function that gets called while the sound is playing. It receives an object with properties `position` and `duration`.
 * *onFinishedPlaying (function)*: Function that gets called when the sound finishes playing (reached end of sound). It receives no parameters.
+* *debug (boolean)*: Boolean that sets [soundmanager2 `debugMode`](http://www.schillmania.com/projects/soundmanager2/doc/technotes/#debug-output) either on or off. Default set to `false`.
 
 ## How to contribute
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ let initialized = false;
 let soundManager;
 if (typeof window !== 'undefined') {
   soundManager = require('soundmanager2').soundManager;
-  
+
   soundManager.onready(() => {
     pendingCalls.slice().forEach(cb => cb());
   });
@@ -54,7 +54,8 @@ export default class Sound extends React.Component {
     volume: T.number,
     onLoading: T.func,
     onPlaying: T.func,
-    onFinishedPlaying: T.func
+    onFinishedPlaying: T.func,
+    debug: T.bool,
   };
 
   static defaultProps = {
@@ -62,7 +63,8 @@ export default class Sound extends React.Component {
     volume: 100,
     onLoading: noop,
     onPlaying: noop,
-    onFinishedPlaying: noop
+    onFinishedPlaying: noop,
+    debug: false,
   };
 
   componentDidMount() {
@@ -114,6 +116,10 @@ export default class Sound extends React.Component {
       if (this.props.volume !== prevProps.volume) {
         sound.setVolume(this.props.volume);
       }
+
+      if (this.props.debug !== prevProps.debug) {
+        this.setDebug(this.props.debug);
+      }
     };
 
     if (this.props.url !== prevProps.url) {
@@ -127,6 +133,8 @@ export default class Sound extends React.Component {
     this.removeSound();
 
     const props = this.props;
+
+    this.setDebug(props.debug);
 
     if (!props.url) { return; }
 
@@ -161,6 +169,10 @@ export default class Sound extends React.Component {
 
       delete this.sound;
     }
+  }
+
+  setDebug(debugMode=false) {
+    soundManager.setup({ debugMode });
   }
 
   render() {


### PR DESCRIPTION
Hi,

I just started using `react-sound` and felt quite annoyed by all the debug output in the console.

You can now use the `debug` prop to set `debugMode` either on or off:

```jsx
<Sound
  debug={true}
  ...
/>
```
I set its default to `false`.

Hope this feature could be helpful to someone else! :)