### PR TITLE
Add Buffer Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ class MyComponentWithSound extends React.Component {
 * *onStop (function)*: Function that gets called while the sound playback is stopped. It receives an object with properties `position` and `duration`.
 * *onFinishedPlaying (function)*: Function that gets called when the sound finishes playing (reached end of sound). It receives no parameters.
 * *onBufferChange (function)*: Function that gets called when the sound buffering status changes. It receives a single boolean representing the buffer state.
+
 ## How to contribute
 
 Feel free to fork and send PRs or issues, be it for features, bug fixes, or documentation!

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ class MyComponentWithSound extends React.Component {
 * *onResume (function)*: Function that gets called while the sound is resumed playing. It receives an object with properties `position` and `duration`.
 * *onStop (function)*: Function that gets called while the sound playback is stopped. It receives an object with properties `position` and `duration`.
 * *onFinishedPlaying (function)*: Function that gets called when the sound finishes playing (reached end of sound). It receives no parameters.
-
+* *onBufferChange (function)*: Function that gets called when the sound buffering status changes. It receives a single boolean representing the buffer state.
 ## How to contribute
 
 Feel free to fork and send PRs or issues, be it for features, bug fixes, or documentation!

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ export default class Sound extends React.Component {
     onResume: PropTypes.func,
     onStop: PropTypes.func,
     onFinishedPlaying: PropTypes.func,
+    onBufferChange: PropTypes.func,
     autoLoad: PropTypes.bool,
     loop: PropTypes.bool,
   };
@@ -81,6 +82,7 @@ export default class Sound extends React.Component {
     onResume: noop,
     onStop: noop,
     onFinishedPlaying: noop,
+    onBufferChange: noop,
     autoLoad: false,
     loop: false,
   };
@@ -185,6 +187,9 @@ export default class Sound extends React.Component {
         } else {
           instance.props.onFinishedPlaying();
         }
+      },
+      onbufferchange() {
+        instance.props.onBufferChange(this.isBuffering);
       }
     }, sound => {
       this.sound = sound;


### PR DESCRIPTION
This PR adds a `onBufferChange` prop method handler for changing buffer state based on SM2s own internal onbufferchange method. Rather than pass the entire SMSound `this` object it only returns a boolean that can then be used to modify the UI as necessary.

Also adds relevant info to README