### PR TITLE
Add 'solo' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ class MyComponentWithSound extends React.Component {
 * *playbackRate (number)*: Number affecting sound playback. A value between 0.5 and 4 of normal rate (1).
 * *autoLoad (boolean)*: If the sound should start loading automatically (defaults to `false`).
 * *loop (boolean)*: If the sound should continue playing in a loop (defaults to `false`).
+* *muted (boolean)*: Mutes the sound without affecting volume setting (defaults to `false`).
 * *onError (function)*: Function that gets called when the sound fails to load, or fails during load or playback. It receives the arguments `errorCode` and `description` with details about the error.
 * *onLoading (function)*: Function that gets called while the sound is loading. It receives an object with properties `bytesLoaded`, `bytesTotal` and `duration`.
 * *onLoad (function)*: Function that gets called after the sound has finished loading. It receives an object with property `loaded`, a boolean set to true if the sound has finished loading successfully.

--- a/examples/src/Example.js
+++ b/examples/src/Example.js
@@ -15,6 +15,7 @@ export default class Example extends React.Component {
       volume: 100,
       playbackRate: 1,
       loop: false,
+      muted: false,
       playStatus: Sound.status.PLAYING
     };
   }
@@ -52,7 +53,7 @@ export default class Example extends React.Component {
   }
 
   render() {
-    const { volume, playbackRate, loop } = this.state;
+    const { volume, playbackRate, loop, muted } = this.state;
 
     return (
       <div>
@@ -66,6 +67,7 @@ export default class Example extends React.Component {
         <PlayerControls
           playStatus={this.state.playStatus}
           loop={loop}
+          muted={muted}
           onPlay={() => this.setState({ playStatus: Sound.status.PLAYING })}
           onPause={() => this.setState({ playStatus: Sound.status.PAUSED })}
           onResume={() => this.setState({ playStatus: Sound.status.PLAYING })}
@@ -76,6 +78,7 @@ export default class Example extends React.Component {
           onPlaybackRateUp={() => this.setState({ playbackRate: playbackRate >= 4 ? playbackRate : playbackRate + 0.5 })}
           onPlaybackRateDown={() => this.setState({ playbackRate: playbackRate <= 0.5 ? playbackRate : playbackRate - 0.5 })}
           onToggleLoop={e => this.setState({ loop: e.target.checked })}
+          onToggleMute={e => this.setState({ muted: e.target.checked })}
           duration={this.state.currentSong ? this.state.currentSong.duration : 0}
           position={this.state.position}
           playbackRate={playbackRate}
@@ -89,6 +92,7 @@ export default class Example extends React.Component {
               volume={volume}
               playbackRate={playbackRate}
               loop={loop}
+              muted={muted}
               onLoading={({ bytesLoaded, bytesTotal }) => console.log(`${bytesLoaded / bytesTotal * 100}% loaded`)}
               onLoad={() => console.log('Loaded')}
               onPlaying={({ position }) => this.setState({ position })}
@@ -105,6 +109,7 @@ export default class Example extends React.Component {
               volume={volume}
               playbackRate={playbackRate}
               loop={loop}
+              muted={muted}
               onLoading={({ bytesLoaded, bytesTotal }) => console.log(`${bytesLoaded / bytesTotal * 100}% loaded`)}
               onLoad={() => console.log('Loaded')}
               onPlaying={({ position }) => console.log('Position', position)}

--- a/examples/src/PlayerControls.js
+++ b/examples/src/PlayerControls.js
@@ -49,8 +49,14 @@ export default class PlayerControls extends React.Component {
           {' '}
           <button onClick={this.props.onPlaybackRateUp}>+</button>
         </div>
-        Loop?:
-        <input type="checkbox" checked={this.props.loop} onChange={this.props.onToggleLoop} />
+        <div>
+          Loop?:
+          <input type="checkbox" checked={this.props.loop} onChange={this.props.onToggleLoop} />
+          </div>
+        <div>
+          Mute?:
+          <input type="checkbox" checked={this.props.muted} onChange={this.props.onToggleMute} />
+        </div>
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,7 @@ export default class Sound extends React.Component {
     onBufferChange: PropTypes.func,
     autoLoad: PropTypes.bool,
     loop: PropTypes.bool,
+    muted: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -85,6 +86,7 @@ export default class Sound extends React.Component {
     onBufferChange: noop,
     autoLoad: false,
     loop: false,
+    muted: false,
   };
 
   componentDidMount() {
@@ -145,6 +147,14 @@ export default class Sound extends React.Component {
     if (this.props.playbackRate !== prevProps.playbackRate) {
       sound.setPlaybackRate(this.props.playbackRate);
     }
+
+    if (this.props.muted !== prevProps.muted) {
+      if (this.props.muted) {
+        sound.mute();
+      } else {
+        sound.unmute();
+      }
+    }
   }
 
   createSound(callback) {
@@ -190,7 +200,8 @@ export default class Sound extends React.Component {
       },
       onbufferchange() {
         instance.props.onBufferChange(this.isBuffering);
-      }
+      },
+      muted: instance.props.muted,
     }, sound => {
       this.sound = sound;
       callback(sound);

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,7 @@ export default class Sound extends React.Component {
     autoLoad: PropTypes.bool,
     loop: PropTypes.bool,
     muted: PropTypes.bool,
+    solo: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -87,6 +88,7 @@ export default class Sound extends React.Component {
     autoLoad: false,
     loop: false,
     muted: false,
+    solo: false,
   };
 
   componentDidMount() {
@@ -110,10 +112,16 @@ export default class Sound extends React.Component {
 
     if (this.props.playStatus === playStatuses.PLAYING) {
       if (sound.playState === 0) {
+        if (this.props.solo) {
+          soundManager.stopAll()
+        }
         sound.play();
       }
 
       if (sound.paused) {
+        if (this.props.solo) {
+          soundManager.stopAll()
+        }
         sound.resume();
       }
     } else if (this.props.playStatus === playStatuses.STOPPED) {


### PR DESCRIPTION
For when you have multiple sound elements on a page, enabling solo will stop all playing sounds when one is started/resumed