### PR TITLE
package.json update so it works with React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "soundmanager2": "^2.97.20170602"
   },
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0-0"
+    "react": "^15.3.0 || ^16.0.0-0 || ^18.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Seems to work with React 18, updated package dependencies so we don't have build issues using it. 